### PR TITLE
[googlebigtable] migrate bigtable connector to using the Google recommended client

### DIFF
--- a/googlebigtable/README.md
+++ b/googlebigtable/README.md
@@ -69,7 +69,7 @@ The following options can be configured using CLI (using the `-p` parameter) or 
 * `columnfamily`: (Required) The Bigtable column family to target.
 * `google.bigtable.project.id`: (Required) The ID of a Bigtable project.
 * `google.bigtable.instance.id`: (Required) The name of a Bigtable instance.
-* `google.bigtable.auth.service.account.enable`: Whether or not to authenticate with a service account. The default is true.
 * `google.bigtable.auth.json.keyfile`: (Required) A service account key for authentication.
 * `debug`: If true, prints debug information to standard out. The default is false.
 * `clientbuffering`: Whether or not to use client side buffering and batching of write operations. This can significantly improve performance and defaults to true.
+* ``

--- a/googlebigtable/pom.xml
+++ b/googlebigtable/pom.xml
@@ -63,7 +63,6 @@ LICENSE file.
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/googlebigtable/pom.xml
+++ b/googlebigtable/pom.xml
@@ -29,11 +29,22 @@ LICENSE file.
   <name>Google Cloud Bigtable Binding</name>
   <packaging>jar</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-bom</artifactId>
+        <version>${googlebigtable.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-hbase-1.x</artifactId>
-      <version>${googlebigtable.version}</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
     </dependency>
     
     <dependency>
@@ -42,6 +53,21 @@ LICENSE file.
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
+++ b/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
@@ -99,6 +99,7 @@ public class GoogleBigtableClient extends site.ycsb.DB {
   private static synchronized BigtableDataClient getOrCreateClient(Properties properties)
       throws DBException {
     if (clientRefcount > 0) {
+      clientRefcount++;
       return client;
     }
 

--- a/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
+++ b/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
@@ -16,381 +16,351 @@
  */
 package site.ycsb.db;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
+import com.google.api.gax.batching.Batcher;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
+import com.google.cloud.bigtable.data.v2.models.MutationApi;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowCell;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.util.Bytes;
-
 import java.util.Set;
 import java.util.Vector;
-import java.util.concurrent.ExecutionException;
-
-import com.google.bigtable.v2.Column;
-import com.google.bigtable.v2.Family;
-import com.google.bigtable.v2.MutateRowRequest;
-import com.google.bigtable.v2.Mutation;
-import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.Row;
-import com.google.bigtable.v2.RowFilter;
-import com.google.bigtable.v2.RowRange;
-import com.google.bigtable.v2.RowSet;
-import com.google.bigtable.v2.Mutation.DeleteFromRow;
-import com.google.bigtable.v2.Mutation.SetCell;
-import com.google.bigtable.v2.RowFilter.Chain.Builder;
-import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.grpc.BigtableDataClient;
-import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
-import com.google.cloud.bigtable.grpc.async.BulkMutation;
-import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
-import com.google.cloud.bigtable.util.ByteStringer;
-import com.google.protobuf.ByteString;
-import site.ycsb.ByteArrayByteIterator;
+import javax.annotation.Nullable;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
+import site.ycsb.InputStreamByteIterator;
 import site.ycsb.Status;
 
 /**
- * Google Bigtable Proto client for YCSB framework.
- * 
- * Bigtable offers two APIs. These include a native Protobuf GRPC API as well as 
- * an HBase API wrapper for the GRPC API. This client implements the Protobuf 
- * API to test the underlying calls wrapped up in the HBase API. To use the 
- * HBase API, see the hbase10 client binding.
+ * Google Bigtable native client for YCSB framework.
+ *
+ * <p>Bigtable offers two APIs. These include a native API as well as an HBase API
+ * wrapper for the GRPC API. This client implements the native API to test the underlying calls
+ * wrapped up in the HBase API. To use the HBase API, see the hbase10 client binding.
  */
 public class GoogleBigtableClient extends site.ycsb.DB {
   public static final Charset UTF8_CHARSET = Charset.forName("UTF8");
-  
+
   /** Property names for the CLI. */
-  private static final String ASYNC_MUTATOR_MAX_MEMORY = "mutatorMaxMemory";
-  private static final String ASYNC_MAX_INFLIGHT_RPCS = "mutatorMaxInflightRPCs";
-  private static final String CLIENT_SIDE_BUFFERING = "clientbuffering";
-  
-  /** Tracks running thread counts so we know when to close the session. */ 
-  private static int threadCount = 0;
-  
-  /** This will load the hbase-site.xml config file and/or store CLI options. */
-  private static final Configuration CONFIG = HBaseConfiguration.create();
-  
+  static final String EMULATOR_HOST_KEY = "google.bigtable.emulator_host";
+
+  static final String PROJECT_KEY = "google.bigtable.project.id";
+  static final String INSTANCE_KEY = "google.bigtable.instance.id";
+  static final String JSON_KEY_FILE_KEY = "google.bigtable.auth.json.keyfile";
+  static final String DEBUG_KEY = "debug";
+  static final String COLUMN_FAMILY_KEY = "columnfamily";
+
+  static final String ASYNC_MUTATOR_MAX_MEMORY = "mutatorMaxMemory";
+  static final String ASYNC_MAX_INFLIGHT_RPCS = "mutatorMaxInflightRPCs";
+  static final String CLIENT_SIDE_BUFFERING = "clientbuffering";
+
+  /** Shared bigtable client instance. */
+  private static BigtableDataClient client = null;
+
+  private static int clientRefcount = 0;
+
   /** Print debug information to standard out. */
   private boolean debug = false;
-  
-  /** Global Bigtable native API objects. */ 
-  private static BigtableOptions options;
-  private static BigtableSession session;
-  
-  /** Thread local Bigtable native API objects. */
-  private BigtableDataClient client;
 
   /** The column family use for the workload. */
-  private byte[] columnFamilyBytes;
-  
-  /** Cache for the last table name/ID to avoid byte conversions. */
-  private String lastTable = "";
-  private byte[] lastTableBytes;
-  
+  private String columnFamily;
+
   /**
-   * If true, buffer mutations on the client. For measuring insert/update/delete 
-   * latencies, client side buffering should be disabled.
+   * If true, buffer mutations on the client. For measuring insert/update/delete latencies, client
+   * side buffering should be disabled.
    */
   private boolean clientSideBuffering = false;
 
-  private BulkMutation bulkMutation;
+  private Map<String, Batcher<RowMutationEntry, Void>> batchers = new HashMap<>();
+
+  private static synchronized BigtableDataClient getOrCreateClient(Properties properties)
+      throws DBException {
+    if (clientRefcount > 0) {
+      return client;
+    }
+
+    // Extract the properties
+    @Nullable String emulatorHost = properties.getProperty(EMULATOR_HOST_KEY, null);
+
+    String projectId =
+        Preconditions.checkNotNull(
+            properties.getProperty(PROJECT_KEY), "%s property must be set", PROJECT_KEY);
+    String instanceId =
+        Preconditions.checkNotNull(
+            properties.getProperty(INSTANCE_KEY), "%s property must be set", INSTANCE_KEY);
+    @Nullable String jsonKeyFilePath = properties.getProperty(JSON_KEY_FILE_KEY, null);
+    boolean clientBufferingEnabled =
+        Boolean.parseBoolean(properties.getProperty(CLIENT_SIDE_BUFFERING, "true"));
+    @Nullable Long maxMemory = null;
+    if (properties.contains(ASYNC_MUTATOR_MAX_MEMORY)) {
+      maxMemory = Long.parseLong(properties.getProperty(ASYNC_MUTATOR_MAX_MEMORY));
+    }
+    @Nullable Long maxRpcs = null;
+    if (properties.contains(ASYNC_MAX_INFLIGHT_RPCS)) {
+      maxRpcs = Long.parseLong(properties.getProperty(ASYNC_MAX_INFLIGHT_RPCS));
+    }
+
+    BigtableDataSettings.Builder builder;
+    if (emulatorHost != null) {
+      int index = emulatorHost.lastIndexOf(":");
+      String host = "localhost";
+      int port;
+      if (index > 0) {
+        host = emulatorHost.substring(0, index);
+        port = Integer.parseInt(emulatorHost.substring(index + 1));
+      } else {
+        port = Integer.parseInt(emulatorHost);
+      }
+      builder = BigtableDataSettings.newBuilderForEmulator(host, port);
+    } else {
+      builder = BigtableDataSettings.newBuilder();
+    }
+
+    builder.setProjectId(projectId).setInstanceId(instanceId);
+
+    if (jsonKeyFilePath != null) {
+      try (FileInputStream fin = new FileInputStream(jsonKeyFilePath)) {
+        builder
+            .stubSettings()
+            .setCredentialsProvider(
+                FixedCredentialsProvider.create(GoogleCredentials.fromStream(fin)));
+      } catch (IOException e) {
+        throw new DBException(
+            String.format("Failed to load credentials specified at path %s", jsonKeyFilePath), e);
+      }
+    }
+
+    if (clientBufferingEnabled) {
+      BatchingSettings defaultBatchingSettings =
+          builder.stubSettings().bulkMutateRowsSettings().getBatchingSettings();
+      FlowControlSettings.Builder flowControlSettings =
+          defaultBatchingSettings.getFlowControlSettings().toBuilder();
+
+      if (maxMemory != null) {
+        flowControlSettings.setMaxOutstandingRequestBytes(maxMemory);
+      }
+      if (maxRpcs != null) {
+        flowControlSettings.setMaxOutstandingElementCount(
+            defaultBatchingSettings.getElementCountThreshold() * maxRpcs);
+      }
+      builder
+          .stubSettings()
+          .bulkMutateRowsSettings()
+          .setBatchingSettings(
+              defaultBatchingSettings.toBuilder()
+                  .setFlowControlSettings(flowControlSettings.build())
+                  .build());
+    }
+
+    try {
+      client = BigtableDataClient.create(builder.build());
+    } catch (IOException e) {
+      throw new DBException("Failed to construct the Bigtable client", e);
+    }
+    clientRefcount++;
+    return client;
+  }
+
+  private static synchronized void releaseClient() {
+    if (--clientRefcount >= 0) {
+      return;
+    }
+    client.close();
+  }
 
   @Override
   public void init() throws DBException {
     Properties props = getProperties();
-    
-    // Defaults the user can override if needed
-    if (getProperties().containsKey(ASYNC_MUTATOR_MAX_MEMORY)) {
-      CONFIG.set(BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY,
-          getProperties().getProperty(ASYNC_MUTATOR_MAX_MEMORY));
-    }
-    if (getProperties().containsKey(ASYNC_MAX_INFLIGHT_RPCS)) {
-      CONFIG.set(BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT,
-          getProperties().getProperty(ASYNC_MAX_INFLIGHT_RPCS));
-    }
-    // make it easy on ourselves by copying all CLI properties into the config object.
-    final Iterator<Entry<Object, Object>> it = props.entrySet().iterator();
-    while (it.hasNext()) {
-      Entry<Object, Object> entry = it.next();
-      CONFIG.set((String)entry.getKey(), (String)entry.getValue());
-    }
-    
-    clientSideBuffering = getProperties()
-        .getProperty(CLIENT_SIDE_BUFFERING, "false").equals("true");
-    
-    System.err.println("Running Google Bigtable with Proto API" +
-         (clientSideBuffering ? " and client side buffering." : "."));
-    
-    synchronized (CONFIG) {
-      ++threadCount;
-      if (session == null) {
-        try {
-          options = BigtableOptionsFactory.fromConfiguration(CONFIG);
-          session = new BigtableSession(options);
-          // important to instantiate the first client here, otherwise the
-          // other threads may receive an NPE from the options when they try
-          // to read the cluster name.
-          client = session.getDataClient();
-        } catch (IOException e) {
-          throw new DBException("Error loading options from config: ", e);
-        }
-      } else {
-        client = session.getDataClient();
-      }
-    }
-    
-    if ((getProperties().getProperty("debug") != null)
-        && (getProperties().getProperty("debug").compareTo("true") == 0)) {
-      debug = true;
-    }
-    
-    final String columnFamily = getProperties().getProperty("columnfamily");
+
+    clientSideBuffering =
+        Boolean.parseBoolean(getProperties().getProperty(CLIENT_SIDE_BUFFERING, "false"));
+
+    System.err.println(
+        "Running Google Bigtable with Proto API"
+            + (clientSideBuffering ? " and client side buffering." : "."));
+
+    getOrCreateClient(props);
+
+    debug = Boolean.parseBoolean(props.getProperty(DEBUG_KEY, "false"));
+
+    columnFamily = getProperties().getProperty(COLUMN_FAMILY_KEY);
     if (columnFamily == null) {
-      System.err.println("Error, must specify a columnfamily for Bigtable table");
-      throw new DBException("No columnfamily specified");
+      throw new DBException(String.format("%s must be specified", COLUMN_FAMILY_KEY));
     }
-    columnFamilyBytes = Bytes.toBytes(columnFamily);
   }
-  
+
   @Override
   public void cleanup() throws DBException {
-    if (bulkMutation != null) {
+    List<Exception> exceptions = new ArrayList<>();
+
+    for (Entry<String, Batcher<RowMutationEntry, Void>> enry : batchers.entrySet()) {
       try {
-        bulkMutation.flush();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new DBException(e);
-      } catch(RuntimeException e){
-        throw new DBException(e);
+        enry.getValue().close();
+      } catch (RuntimeException | InterruptedException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        exceptions.add(e);
       }
     }
 
-    synchronized (CONFIG) {
-      --threadCount;
-      if (threadCount <= 0) {
-        try {
-          session.close();
-        } catch (IOException e) {
-          throw new DBException(e);
-        }
-      }
+    try {
+      releaseClient();
+    } catch (RuntimeException e) {
+      exceptions.add(e);
+    }
+
+    if (!exceptions.isEmpty()) {
+      DBException parentError = new DBException("Failed to cleanup Bigtable client resources");
+      exceptions.forEach(parentError::addSuppressed);
+      throw parentError;
     }
   }
-  
+
+  private Batcher<RowMutationEntry, Void> getOrCreateBatcher(String tableId) {
+    return batchers.computeIfAbsent(tableId, client::newBulkMutationBatcher);
+  }
+
   @Override
-  public Status read(String table, String key, Set<String> fields,
-                     Map<String, ByteIterator> result) {
+  public Status read(
+      String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
     if (debug) {
-      System.out.println("Doing read from Bigtable columnfamily " 
-          + new String(columnFamilyBytes));
+      System.out.println("Doing read from Bigtable columnfamily " + columnFamily);
       System.out.println("Doing read for key: " + key);
     }
-    
-    setTable(table);
-    
-    RowFilter filter = RowFilter.newBuilder()
-        .setFamilyNameRegexFilterBytes(ByteStringer.wrap(columnFamilyBytes))
-        .build();
-    if (fields != null && fields.size() > 0) {
-      Builder filterChain = RowFilter.Chain.newBuilder();
-      filterChain.addFilters(filter);
-      filterChain.addFilters(RowFilter.newBuilder()
-          .setCellsPerColumnLimitFilter(1)
-          .build());
-      int count = 0;
-      // usually "field#" so pre-alloc
-      final StringBuilder regex = new StringBuilder(fields.size() * 6);
-      for (final String field : fields) {
-        if (count++ > 0) {
-          regex.append("|");
-        }
-        regex.append(field);
-      }
-      filterChain.addFilters(RowFilter.newBuilder()
-          .setColumnQualifierRegexFilter(
-              ByteStringer.wrap(regex.toString().getBytes()))).build();
-      filter = RowFilter.newBuilder().setChain(filterChain.build()).build();
+
+    Filter filter = FILTERS.family().exactMatch(columnFamily);
+    if (fields != null && !fields.isEmpty()) {
+      filter =
+          FILTERS
+              .chain()
+              .filter(filter)
+              .filter(FILTERS.limit().cellsPerColumn(1))
+              .filter(FILTERS.qualifier().regex(Joiner.on("|").join(fields)));
     }
-    
-    final ReadRowsRequest.Builder rrr = ReadRowsRequest.newBuilder()
-        .setTableNameBytes(ByteStringer.wrap(lastTableBytes))
-        .setFilter(filter)
-        .setRows(RowSet.newBuilder()
-          .addRowKeys(ByteStringer.wrap(key.getBytes())));
-    
-    List<Row> rows;
+
     try {
-      rows = client.readRowsAsync(rrr.build()).get();
-      if (rows == null || rows.isEmpty()) {
-        return Status.NOT_FOUND;
-      }
-      for (final Row row : rows) {
-        for (final Family family : row.getFamiliesList()) {
-          if (Arrays.equals(family.getNameBytes().toByteArray(), columnFamilyBytes)) {
-            for (final Column column : family.getColumnsList()) {
-              // we should only have a single cell per column
-              result.put(column.getQualifier().toString(UTF8_CHARSET), 
-                  new ByteArrayByteIterator(column.getCells(0).getValue().toByteArray()));
-              if (debug) {
-                System.out.println(
-                    "Result for field: " + column.getQualifier().toString(UTF8_CHARSET)
-                        + " is: " + column.getCells(0).getValue().toString(UTF8_CHARSET));
-              }
-            }
-          }
+      for (RowCell cell : client.readRow(table, key, filter).getCells()) {
+        result.put(cell.getQualifier().toString(UTF8_CHARSET), wrapByteString(cell.getValue()));
+
+        if (debug) {
+          System.out.println(
+              "Result for field: "
+                  + cell.getQualifier().toString(UTF8_CHARSET)
+                  + " is: "
+                  + cell.getValue().toString(UTF8_CHARSET));
         }
       }
-      
+
       return Status.OK;
-    } catch (InterruptedException e) {
-      System.err.println("Interrupted during get: " + e);
-      Thread.currentThread().interrupt();
-      return Status.ERROR;
-    } catch (ExecutionException e) {
-      System.err.println("Exception during get: " + e);
+    } catch (RuntimeException e) {
       return Status.ERROR;
     }
   }
 
   @Override
-  public Status scan(String table, String startkey, int recordcount,
-      Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
-    setTable(table);
-    
-    RowFilter filter = RowFilter.newBuilder()
-        .setFamilyNameRegexFilterBytes(ByteStringer.wrap(columnFamilyBytes))
-        .build();
-    if (fields != null && fields.size() > 0) {
-      Builder filterChain = RowFilter.Chain.newBuilder();
-      filterChain.addFilters(filter);
-      filterChain.addFilters(RowFilter.newBuilder()
-          .setCellsPerColumnLimitFilter(1)
-          .build());
-      int count = 0;
-      // usually "field#" so pre-alloc
-      final StringBuilder regex = new StringBuilder(fields.size() * 6);
-      for (final String field : fields) {
-        if (count++ > 0) {
-          regex.append("|");
-        }
-        regex.append(field);
-      }
-      filterChain.addFilters(RowFilter.newBuilder()
-          .setColumnQualifierRegexFilter(
-              ByteStringer.wrap(regex.toString().getBytes()))).build();
-      filter = RowFilter.newBuilder().setChain(filterChain.build()).build();
+  public Status scan(
+      String table,
+      String startkey,
+      int recordcount,
+      Set<String> fields,
+      Vector<HashMap<String, ByteIterator>> result) {
+
+    Filter filter = FILTERS.family().exactMatch(columnFamily);
+    if (fields != null && !fields.isEmpty()) {
+      filter =
+          FILTERS
+              .chain()
+              .filter(filter)
+              .filter(FILTERS.limit().cellsPerColumn(1))
+              .filter(FILTERS.qualifier().regex(Joiner.on("|").join(fields)));
     }
-    
-    final RowRange range = RowRange.newBuilder()
-        .setStartKeyClosed(ByteStringer.wrap(startkey.getBytes()))
-        .build();
 
-    final RowSet rowSet = RowSet.newBuilder()
-        .addRowRanges(range)
-        .build();
+    Query query =
+        Query.create(table)
+            .filter(filter)
+            .range(ByteStringRange.unbounded().startClosed(startkey))
+            .limit(recordcount);
 
-    final ReadRowsRequest.Builder rrr = ReadRowsRequest.newBuilder()
-        .setTableNameBytes(ByteStringer.wrap(lastTableBytes))
-        .setFilter(filter)
-        .setRows(rowSet);
-    
     List<Row> rows;
     try {
-      rows = client.readRowsAsync(rrr.build()).get();
-      if (rows == null || rows.isEmpty()) {
-        return Status.NOT_FOUND;
-      }
-      int numResults = 0;
-      
-      for (final Row row : rows) {
-        final HashMap<String, ByteIterator> rowResult =
-            new HashMap<String, ByteIterator>(fields != null ? fields.size() : 10);
-        
-        for (final Family family : row.getFamiliesList()) {
-          if (Arrays.equals(family.getNameBytes().toByteArray(), columnFamilyBytes)) {
-            for (final Column column : family.getColumnsList()) {
-              // we should only have a single cell per column
-              rowResult.put(column.getQualifier().toString(UTF8_CHARSET), 
-                  new ByteArrayByteIterator(column.getCells(0).getValue().toByteArray()));
-              if (debug) {
-                System.out.println(
-                    "Result for field: " + column.getQualifier().toString(UTF8_CHARSET)
-                        + " is: " + column.getCells(0).getValue().toString(UTF8_CHARSET));
-              }
-            }
-          }
-        }
-        
-        result.add(rowResult);
-        
-        numResults++;
-        if (numResults >= recordcount) {// if hit recordcount, bail out
-          break;
-        }
-      }
-      return Status.OK;
-    } catch (InterruptedException e) {
-      System.err.println("Interrupted during scan: " + e);
-      Thread.currentThread().interrupt();
-      return Status.ERROR;
-    } catch (ExecutionException e) {
+      rows = client.readRowsCallable().all().call(query);
+    } catch (RuntimeException e) {
       System.err.println("Exception during scan: " + e);
       return Status.ERROR;
     }
+
+    if (rows.isEmpty()) {
+      return Status.NOT_FOUND;
+    }
+
+    for (Row row : rows) {
+      HashMap<String, ByteIterator> rowResult = new HashMap<>();
+      for (RowCell cell : row.getCells()) {
+        rowResult.put(cell.getQualifier().toString(UTF8_CHARSET), wrapByteString(cell.getValue()));
+        if (debug) {
+          System.out.println(
+              "Result for field: "
+                  + cell.getQualifier().toString(UTF8_CHARSET)
+                  + " is: "
+                  + cell.getValue().toString(UTF8_CHARSET));
+        }
+      }
+      result.add(rowResult);
+    }
+
+    return Status.OK;
   }
 
   @Override
-  public Status update(String table, String key,
-                       Map<String, ByteIterator> values) {
+  public Status update(String table, String key, Map<String, ByteIterator> values) {
     if (debug) {
       System.out.println("Setting up put for key: " + key);
     }
-    
-    setTable(table);
-    
-    final MutateRowRequest.Builder rowMutation = MutateRowRequest.newBuilder();
-    rowMutation.setRowKey(ByteString.copyFromUtf8(key));
-    rowMutation.setTableNameBytes(ByteStringer.wrap(lastTableBytes));
-    
-    for (final Entry<String, ByteIterator> entry : values.entrySet()) {
-      final Mutation.Builder mutationBuilder = rowMutation.addMutationsBuilder();
-      final SetCell.Builder setCellBuilder = mutationBuilder.getSetCellBuilder();
-      
-      setCellBuilder.setFamilyNameBytes(ByteStringer.wrap(columnFamilyBytes));
-      setCellBuilder.setColumnQualifier(ByteStringer.wrap(entry.getKey().getBytes()));
-      setCellBuilder.setValue(ByteStringer.wrap(entry.getValue().toArray()));
 
-      // Bigtable uses a 1ms granularity
-      setCellBuilder.setTimestampMicros(System.currentTimeMillis() * 1000);
-    }
-    
-    try {
-      if (clientSideBuffering) {
-        bulkMutation.add(rowMutation.build());
-      } else {
-        client.mutateRow(rowMutation.build());
+    if (clientSideBuffering) {
+      RowMutationEntry entry = RowMutationEntry.create(key);
+      populateMutations(values, entry);
+      getOrCreateBatcher(table).add(entry);
+      return Status.BATCHED_OK;
+    } else {
+      RowMutation rowMutation = RowMutation.create(table, key);
+      populateMutations(values, rowMutation);
+      try {
+        client.mutateRow(rowMutation);
+        return Status.OK;
+      } catch (RuntimeException e) {
+        System.err.println("Failed to insert key: " + key + " " + e.getMessage());
+        return Status.ERROR;
       }
-      return Status.OK;
-    } catch (RuntimeException e) {
-      System.err.println("Failed to insert key: " + key + " " + e.getMessage());
-      return Status.ERROR;
     }
   }
 
   @Override
-  public Status insert(String table, String key,
-                       Map<String, ByteIterator> values) {
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
     return update(table, key, values);
   }
 
@@ -399,54 +369,36 @@ public class GoogleBigtableClient extends site.ycsb.DB {
     if (debug) {
       System.out.println("Doing delete for key: " + key);
     }
-    
-    setTable(table);
-    
-    final MutateRowRequest.Builder rowMutation = MutateRowRequest.newBuilder()
-        .setRowKey(ByteString.copyFromUtf8(key))
-        .setTableNameBytes(ByteStringer.wrap(lastTableBytes));
-    rowMutation.addMutationsBuilder().setDeleteFromRow(
-        DeleteFromRow.getDefaultInstance());
-    
-    try {
-      if (clientSideBuffering) {
-        bulkMutation.add(rowMutation.build());
-      } else {
-        client.mutateRow(rowMutation.build());
+
+    if (clientSideBuffering) {
+      getOrCreateBatcher(table).add(RowMutationEntry.create(key).deleteRow());
+      return Status.BATCHED_OK;
+    } else {
+      try {
+        client.mutateRow(RowMutation.create(table, key).deleteRow());
+        return Status.OK;
+      } catch (RuntimeException e) {
+        System.err.println("Failed to delete key: " + key + " " + e.getMessage());
+        return Status.ERROR;
       }
-      return Status.OK;
-    } catch (RuntimeException e) {
-      System.err.println("Failed to delete key: " + key + " " + e.getMessage());
-      return Status.ERROR;
     }
   }
 
-  /**
-   * Little helper to set the table byte array. If it's different than the last
-   * table we reset the byte array. Otherwise we just use the existing array.
-   * @param table The table we're operating against
-   */
-  private void setTable(final String table) {
-    if (!lastTable.equals(table)) {
-      lastTable = table;
-      BigtableTableName tableName = options
-          .getInstanceName()
-          .toTableName(table);
-      lastTableBytes = tableName
-          .toString()
-          .getBytes();
-      synchronized(this) {
-        if (bulkMutation != null) {
-          try {
-            bulkMutation.flush();
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-          }
-        }
-        bulkMutation = session.createBulkMutation(tableName);
-      }
+  private void populateMutations(Map<String, ByteIterator> input, MutationApi<?> output) {
+    for (Entry<String, ByteIterator> entry : input.entrySet()) {
+      output.setCell(columnFamily, wrapString(entry.getKey()), wrapByteIterator(entry.getValue()));
     }
   }
-  
+
+  private static ByteIterator wrapByteString(ByteString byteString) {
+    return new InputStreamByteIterator(byteString.newInput(), byteString.size());
+  }
+
+  private static ByteString wrapString(String s) {
+    return ByteString.copyFromUtf8(s);
+  }
+
+  private static ByteString wrapByteIterator(ByteIterator iterator) {
+    return UnsafeByteOperations.unsafeWrap(iterator.toArray());
+  }
 }

--- a/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
+++ b/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
@@ -139,7 +139,10 @@ public class GoogleBigtableClient extends site.ycsb.DB {
       builder = BigtableDataSettings.newBuilder();
     }
 
-    builder.setProjectId(projectId).setInstanceId(instanceId);
+    builder
+        .setProjectId(projectId)
+        .setInstanceId(instanceId)
+        .setRefreshingChannel(true);
 
     if (jsonKeyFilePath != null) {
       try (FileInputStream fin = new FileInputStream(jsonKeyFilePath)) {

--- a/googlebigtable/src/test/java/site/ycsb/db/TestGoogleBigtableClient.java
+++ b/googlebigtable/src/test/java/site/ycsb/db/TestGoogleBigtableClient.java
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2022 YCSB contributors. All rights reserved.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package site.ycsb.db;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.MutateRowRequest;
+import com.google.bigtable.v2.MutateRowResponse;
+import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.MutateRowsRequest.Entry;
+import com.google.bigtable.v2.MutateRowsResponse;
+import com.google.bigtable.v2.Mutation.SetCell;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.ReadRowsResponse;
+import com.google.bigtable.v2.ReadRowsResponse.CellChunk;
+import com.google.bigtable.v2.RowRange;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.google.protobuf.StringValue;
+import com.google.rpc.Code;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.Vector;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import site.ycsb.ByteIterator;
+import site.ycsb.DBException;
+import site.ycsb.Status;
+import site.ycsb.StringByteIterator;
+
+@RunWith(JUnit4.class)
+public class TestGoogleBigtableClient {
+
+  private static final String FAMILY = "my-family";
+  private static final String QUALIFIER = "my-column";
+  private Server fakeServer;
+  private Properties clientProps;
+  private GoogleBigtableClient client;
+  private FakeBigtableService fakeService;
+
+  @Before
+  public void setup() throws DBException {
+    List<IOException> errors = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      try {
+        fakeServer = createServer();
+      } catch (IOException e) {
+        errors.add(e);
+      }
+    }
+    clientProps = new Properties();
+    clientProps.setProperty(
+        GoogleBigtableClient.EMULATOR_HOST_KEY, "localhost:" + fakeServer.getPort());
+    clientProps.setProperty(GoogleBigtableClient.PROJECT_KEY, "fake-project");
+    clientProps.setProperty(GoogleBigtableClient.INSTANCE_KEY, "fake-instance");
+    clientProps.setProperty(GoogleBigtableClient.COLUMN_FAMILY_KEY, FAMILY);
+
+    client = new GoogleBigtableClient();
+    client.setProperties(clientProps);
+    client.init();
+  }
+
+  @After
+  public void teardown() throws DBException {
+    client.cleanup();
+  }
+
+  private Server createServer() throws IOException {
+    int port;
+    try (ServerSocket ss = new ServerSocket(0)) {
+      port = ss.getLocalPort();
+    }
+    fakeService = new FakeBigtableService();
+    return ServerBuilder.forPort(port).addService(fakeService).build().start();
+  }
+
+  @Test
+  public void testRead() {
+    Map<String, ByteIterator> results = new HashMap<>();
+    Status status = client.read("fake-table", "key1", ImmutableSet.of(QUALIFIER), results);
+    Assert.assertEquals(Status.OK, status);
+    Assert.assertEquals(1, results.size());
+    ByteIterator value = results.get(QUALIFIER);
+    Assert.assertEquals("value", value.toString());
+  }
+
+  @Test
+  public void testScan() {
+    Vector<HashMap<String, ByteIterator>> results = new Vector<>();
+    Status status = client.scan("fake-table", "key", 10, ImmutableSet.of(QUALIFIER), results);
+    Assert.assertEquals(Status.OK, status);
+    Assert.assertEquals(10, results.size());
+
+    for (HashMap<String, ByteIterator> result : results) {
+      Assert.assertEquals(1, result.size());
+      ByteIterator value = result.get(QUALIFIER);
+      Assert.assertEquals("value", value.toString());
+    }
+  }
+
+  @Test
+  public void testInsert() throws InterruptedException, DBException {
+    Status status =
+        client.insert(
+            "fake-table", "key1", ImmutableMap.of(QUALIFIER, new StringByteIterator("value")));
+
+    Assert.assertEquals(Status.OK, status);
+    MutateRowRequest req = fakeService.mutateRequests.poll(30, TimeUnit.SECONDS);
+
+    Assert.assertEquals(
+        "projects/fake-project/instances/fake-instance/tables/fake-table", req.getTableName());
+    Assert.assertEquals(ByteString.copyFromUtf8("key1"), req.getRowKey());
+    Assert.assertEquals(1, req.getMutationsCount());
+
+    SetCell setCell = req.getMutations(0).getSetCell();
+    Assert.assertEquals(ByteString.copyFromUtf8(QUALIFIER), setCell.getColumnQualifier());
+    Assert.assertEquals(ByteString.copyFromUtf8("value"), setCell.getValue());
+  }
+
+  @Test
+  public void testInsertBatch() throws InterruptedException, DBException {
+    Properties properties = new Properties(clientProps);
+    properties.setProperty(GoogleBigtableClient.CLIENT_SIDE_BUFFERING, "true");
+
+    GoogleBigtableClient bufferedClient = new GoogleBigtableClient();
+    bufferedClient.setProperties(properties);
+    bufferedClient.init();
+
+    Status status;
+    try {
+      status =
+          bufferedClient.insert(
+              "fake-table", "key1", ImmutableMap.of(QUALIFIER, new StringByteIterator("value")));
+    } finally {
+      bufferedClient.cleanup();
+    }
+    Assert.assertEquals(Status.BATCHED_OK, status);
+    MutateRowsRequest req = fakeService.mutateRowsRequests.poll(30, TimeUnit.SECONDS);
+
+    Assert.assertEquals(
+        "projects/fake-project/instances/fake-instance/tables/fake-table", req.getTableName());
+    Assert.assertEquals(1, req.getEntriesCount());
+    Entry entry = req.getEntries(0);
+    Assert.assertEquals(ByteString.copyFromUtf8("key1"), entry.getRowKey());
+    Assert.assertEquals(1, entry.getMutationsCount());
+    SetCell setCell = entry.getMutations(0).getSetCell();
+    Assert.assertEquals(ByteString.copyFromUtf8(QUALIFIER), setCell.getColumnQualifier());
+    Assert.assertEquals(ByteString.copyFromUtf8("value"), setCell.getValue());
+  }
+
+  private static class FakeBigtableService extends BigtableGrpc.BigtableImplBase {
+
+    private final BlockingQueue<MutateRowRequest> mutateRequests = new LinkedBlockingDeque<>();
+    private final BlockingQueue<MutateRowsRequest> mutateRowsRequests = new LinkedBlockingDeque<>();
+
+    @Override
+    public void readRows(
+        ReadRowsRequest request, StreamObserver<ReadRowsResponse> responseObserver) {
+
+      SortedSet<ByteString> sortedKeys =
+          new TreeSet<>(Comparator.comparing(ByteString::toStringUtf8));
+      sortedKeys.addAll(request.getRows().getRowKeysList());
+      for (ByteString key : sortedKeys) {
+        responseObserver.onNext(
+            ReadRowsResponse.newBuilder()
+                .addChunks(
+                    CellChunk.newBuilder()
+                        .setRowKey(key)
+                        .setFamilyName(StringValue.newBuilder().setValue("f"))
+                        .setQualifier(
+                            BytesValue.newBuilder().setValue(ByteString.copyFromUtf8(QUALIFIER)))
+                        .setTimestampMicros(10_000)
+                        .setValue(ByteString.copyFromUtf8("value"))
+                        .setCommitRow(true))
+                .build());
+      }
+
+      SortedSet<RowRange> ranges =
+          new TreeSet<>(Comparator.comparing(o -> o.getStartKeyClosed().toStringUtf8()));
+      ranges.addAll(request.getRows().getRowRangesList());
+
+      for (RowRange range : ranges) {
+        for (int i = 0; i < request.getRowsLimit(); i++) {
+          ByteString key =
+              range.getStartKeyClosed().concat(ByteString.copyFromUtf8(String.format("-%02d", i)));
+
+          responseObserver.onNext(
+              ReadRowsResponse.newBuilder()
+                  .addChunks(
+                      CellChunk.newBuilder()
+                          .setRowKey(key)
+                          .setFamilyName(StringValue.newBuilder().setValue("family"))
+                          .setQualifier(
+                              BytesValue.newBuilder().setValue(ByteString.copyFromUtf8(QUALIFIER)))
+                          .setTimestampMicros(10_000)
+                          .setValue(ByteString.copyFromUtf8("value"))
+                          .setCommitRow(true))
+                  .build());
+        }
+      }
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void mutateRow(
+        MutateRowRequest request, StreamObserver<MutateRowResponse> responseObserver) {
+      mutateRequests.add(request);
+      responseObserver.onNext(MutateRowResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    }
+
+    @Override
+    public void mutateRows(
+        MutateRowsRequest request, StreamObserver<MutateRowsResponse> responseObserver) {
+      mutateRowsRequests.add(request);
+
+      MutateRowsResponse.Builder response = MutateRowsResponse.newBuilder();
+      for (int i = 0; i < request.getEntriesCount(); i++) {
+        response.addEntries(
+            MutateRowsResponse.Entry.newBuilder()
+                .setIndex(i++)
+                .setStatus(com.google.rpc.Status.newBuilder().setCode(Code.OK.getNumber()))
+                .build());
+      }
+      responseObserver.onNext(response.build());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@ LICENSE file.
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
     <foundationdb.version>5.2.5</foundationdb.version>
     <geode.version>1.2.0</geode.version>
-    <googlebigtable.version>1.4.0</googlebigtable.version>
+    <googlebigtable.version>2.15.0</googlebigtable.version>
     <griddb.version>4.0.0</griddb.version>
     <hbase1.version>1.4.12</hbase1.version>
     <hbase2.version>2.2.3</hbase2.version>


### PR DESCRIPTION
The previous implementation was using bigtable-client-core, which is being replace by java-bigtable. The new client has a nicer api and is actively supported, while bigtable-client-core is effectively frozen. The PR tries maintain backwards compatibility by respecting the old YCSB properties

This is just a staging PR, will reopen in https://github.com/brianfrankcooper/YCSB after initial code review